### PR TITLE
GitHub workflow: flake8: don't treat error as warnings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,5 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
+        flake8 . --count --ignore=W503 --select=E,F,W,C --show-source --statistics
+        flake8 . --count --max-complexity=10 --max-line-length=79 --statistics


### PR DESCRIPTION
And use more strict rules