### PR TITLE
Pylint: unused-argument: replace argument "client" to "_" when it's unused

### DIFF
--- a/wbb/__main__.py
+++ b/wbb/__main__.py
@@ -57,7 +57,7 @@ async def start_bot():
 
 
 @app.on_message(cust_filter.command("start"))
-async def start(client, message):  # pylint: disable=W0613
+async def start(_, message):
     bot_uptime = int(time.time() - bot_start_time)
     await message.reply_text(
         f"Already Online Since {formatter.get_readable_time((bot_uptime))},"

--- a/wbb/modules/admin.py
+++ b/wbb/modules/admin.py
@@ -83,7 +83,7 @@ async def purge(client, message: Message):
 
 
 @app.on_message(cust_filter.command(commands=("kick")))
-async def kick(client, message: Message):  # pylint: disable=W0613
+async def kick(_, message: Message):
     try:
         username = (message.text.split(None, 2)[1])
     except IndexError:
@@ -126,7 +126,7 @@ async def kick(client, message: Message):  # pylint: disable=W0613
 
 
 @app.on_message(cust_filter.command(commands=("ban")))
-async def ban(client, message: Message):  # pylint: disable=W0613
+async def ban(_, message: Message):
     try:
         username = (message.text.split(None, 2)[1])
     except IndexError:
@@ -166,7 +166,7 @@ async def ban(client, message: Message):  # pylint: disable=W0613
 
 
 @app.on_message(cust_filter.command(commands=("unban")))
-async def unban(client, message: Message):  # pylint: disable=W0613
+async def unban(_, message: Message):
     try:
         username = (message.text.split(None, 2)[1])
     except IndexError:
@@ -199,7 +199,7 @@ async def unban(client, message: Message):  # pylint: disable=W0613
 
 
 @app.on_message(cust_filter.command(commands=("kickme")))
-async def kickme(client, message: Message):  # pylint: disable=W0613
+async def kickme(_, message: Message):
     if message.from_user.id not in SUDO:
         await message.chat.kick_member(message.from_user.id)
         await message.chat.unban_member(message.from_user.id)
@@ -211,7 +211,7 @@ async def kickme(client, message: Message):  # pylint: disable=W0613
 
 
 @app.on_message(cust_filter.command(commands=("banme")))
-async def banme(client, message: Message):  # pylint: disable=W0613
+async def banme(_, message: Message):
     if message.from_user.id not in SUDO:
         await message.chat.kick_member(message.from_user.id)
         await message.reply_text("Banned!, Joke's on you, I'm into that shit!")

--- a/wbb/modules/greetings.py
+++ b/wbb/modules/greetings.py
@@ -6,7 +6,7 @@ MESSAGE = "{} Welcome {}!"
 
 
 @app.on_message(filters.new_chat_members)
-async def welcome(client, message: Message):  # pylint: disable=W0613
+async def welcome(_, message: Message):
     new_members = [i.mention for i in message.new_chat_members]
     text = MESSAGE.format(emoji.CROWN, ",  ".join(new_members))
     await message.reply_text(text, disable_web_page_preview=True)

--- a/wbb/modules/images.py
+++ b/wbb/modules/images.py
@@ -19,7 +19,7 @@ async def delete_message_with_delay(delay, message: Message):
 
 
 @app.on_message(cust_filter.command(commands=("cat")))
-async def cat(client, message: Message):  # pylint: disable=W0613
+async def cat(_, message: Message):
     with urllib.request.urlopen(
         "https://api.thecatapi.com/v1/images/search"
     ) as url:
@@ -29,7 +29,7 @@ async def cat(client, message: Message):  # pylint: disable=W0613
 
 
 @app.on_message(cust_filter.command(commands=("dog")))
-async def dog(client, message: Message):  # pylint: disable=W0613
+async def dog(_, message: Message):
     with urllib.request.urlopen(
         "https://api.thedogapi.com/v1/images/search"
     ) as url:
@@ -39,7 +39,7 @@ async def dog(client, message: Message):  # pylint: disable=W0613
 
 
 @app.on_message(cust_filter.command(commands=("wall")))
-async def wall(client, message: Message):  # pylint: disable=W0613
+async def wall(_, message: Message):
     app.set_parse_mode("markdown")
     m = await message.reply_text("Searching!")
     initial_term = (message.text.replace('/wall', ''))

--- a/wbb/modules/misc.py
+++ b/wbb/modules/misc.py
@@ -11,22 +11,22 @@ __HELP__ = "/commit - Generate Funny Commit Messages\n" \
 
 
 @app.on_message(cust_filter.command(commands=("commit")))
-async def commit(client, message: Message):  # pylint: disable=W0613
+async def commit(_, message: Message):
     await message.reply_text((await random_line('wbb/utils/commit.txt')))
 
 
 @app.on_message(cust_filter.command(commands=("runs")))
-async def runs(client, message: Message):  # pylint: disable=W0613
+async def runs(_, message: Message):
     await message.reply_text((await random_line('wbb/utils/runs.txt')))
 
 
 @app.on_message(cust_filter.command(commands=("quote")))
-async def quote(client, message: Message):  # pylint: disable=W0613
+async def quote(_, message: Message):
     await message.reply_text((await random_line('wbb/utils/quotes.txt')))
 
 
 @app.on_message(cust_filter.command(commands=("id")))
-async def get_id(client, message: Message):  # pylint: disable=W0613
+async def get_id(_, message: Message):
     app.set_parse_mode("markdown")
     if message.text != '/id':
         username = message.text.replace('/id', '')
@@ -47,7 +47,7 @@ async def get_id(client, message: Message):  # pylint: disable=W0613
 
 
 @app.on_message(cust_filter.command(commands=("dev")))
-async def dev(client, message: Message):  # pylint: disable=W0613
+async def dev(_, message: Message):
     app.set_parse_mode("markdown")
     await message.reply_to_message.forward('WBBSupport')
     await app.send_message("WBBSupport",

--- a/wbb/modules/music.py
+++ b/wbb/modules/music.py
@@ -16,7 +16,7 @@ ydl_opts = {
 
 
 @app.on_message(cust_filter.command(commands=("music")))
-async def music(client, message: Message):  # pylint: disable=W0613
+async def music(_, message: Message):
     await message.reply_chat_action("typing")
     app.set_parse_mode("html")
     try:

--- a/wbb/modules/paste.py
+++ b/wbb/modules/paste.py
@@ -9,7 +9,7 @@ __HELP__ = "/paste - To Paste Replied Text Or Document To Neokobin"
 
 
 @app.on_message(cust_filter.command(commands=("paste")))
-async def paste(client, message: Message):  # pylint: disable=W0613
+async def paste(_, message: Message):
     if bool(message.reply_to_message) is True:
         app.set_parse_mode("markdown")
         if bool(message.reply_to_message.text) is True:

--- a/wbb/modules/ping.py
+++ b/wbb/modules/ping.py
@@ -8,7 +8,7 @@ __HELP__ = " /ping - To Get Response Time From All TG Datacenters"
 
 
 @app.on_message(cust_filter.command(commands=("ping")))
-async def ping(client, message: Message):  # pylint: disable=W0613
+async def ping(_, message: Message):
     app.set_parse_mode("markdown")
     j = await message.reply_text("Wait, Pinging all Datacenters`")
     result = ""

--- a/wbb/modules/repo.py
+++ b/wbb/modules/repo.py
@@ -9,7 +9,7 @@ __HELP__ = "/repo - To Get My Github Repository Link " + \
 
 
 @app.on_message(cust_filter.command(commands=("repo")))
-async def repo(client, message: Message):  # pylint: disable=W0613
+async def repo(_, message: Message):
     app.set_parse_mode("markdown")
     await message.reply_text(
         "[Github](https://github.com/thehamkercat/WilliamButcherBot)"

--- a/wbb/modules/rice.py
+++ b/wbb/modules/rice.py
@@ -10,7 +10,7 @@ __HELP__ = "/rice - To Forward Your Linux Rice To DE_WM's" \
 
 
 @app.on_message(filters.chat('DE_WM') & cust_filter.command(commands=("rice")))
-async def rice(client, message: Message):  # pylint: disable=W0613
+async def rice(_, message: Message):
     if bool(message.reply_to_message) is True:
         app.set_parse_mode("markdown")
         user_id = message.reply_to_message.from_user.id

--- a/wbb/modules/sudoers.py
+++ b/wbb/modules/sudoers.py
@@ -22,7 +22,7 @@ SUDOERS = [OWNER_ID, SUDO_USER_ID]
 
 
 @app.on_message(filters.user(SUDOERS) & cust_filter.command("log"))
-async def logs_chat(client, message: Message):  # pylint: disable=W0613
+async def logs_chat(_, message: Message):
     keyb = types.InlineKeyboardMarkup(
         [
             [
@@ -77,8 +77,7 @@ def speed_convert(size):
 @app.on_message(
     filters.user(SUDOERS) & cust_filter.command(commands=("speedtest"))
 )
-async def get_speedtest_result(client,  # pylint: disable=W0613
-                               message: Message):
+async def get_speedtest_result(_, message: Message):
     app.set_parse_mode("markdown")
     m = await message.reply_text("```Performing A Speedtest!```")
     speed = speedtest.Speedtest()
@@ -97,7 +96,7 @@ Latency  - {round((i["latency"]))} ms
 @ app.on_message(
     filters.user(SUDOERS) & cust_filter.command(commands=("stats"))
 )
-async def get_stats(client, message: Message):  # pylint: disable=W0613
+async def get_stats(_, message: Message):
     bot_uptime = int(time.time() - bot_start_time)
     cpu = psutil.cpu_percent(interval=0.5)
     mem = psutil.virtual_memory().percent


### PR DESCRIPTION
It's better to do it this way instead of ignore the warning per line.