### PR TITLE
feat: pastebin: support pastes from shell script files

### DIFF
--- a/wbb/modules/paste.py
+++ b/wbb/modules/paste.py
@@ -37,7 +37,7 @@ from wbb.utils.pastebin import paste
 
 __MODULE__ = "Paste"
 __HELP__ = "/paste - To Paste Replied Text Or Document To Nekobin"
-pattern = re.compile(r"^text/|json$|yaml$|xml$|toml$")
+pattern = re.compile(r"^text/|json$|yaml$|xml$|toml$|x-sh$|x-shellscript$")
 
 
 async def isPreviewUp(preview: str) -> bool:


### PR DESCRIPTION
this commit make the bot able to paste from such files

```
        "file_name": "file.sh",
        "mime_type": "application/x-shellscript",
```

