### PR TITLE
.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pykeyboard
 pyrogram
 python-arq
 requests
+search_engine_parser
 speedtest-cli
 TgCrypto
 uvloop

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pykeyboard
 pyrogram
 python-arq
 requests
-search_engine_parser
+search-engine-parser
 speedtest-cli
 TgCrypto
 uvloop


### PR DESCRIPTION
ModuleNotFoundError: No module named 'search_engine_parser'