### PR TITLE
added purge count

### DIFF
--- a/wbb/modules/admin.py
+++ b/wbb/modules/admin.py
@@ -60,6 +60,7 @@ __HELP__ = """/ban - Ban A User
 /kick - Kick A User
 /dkick - Delete the replied message kicking its sender
 /purge - Purge Messages
+/purge [n] - Purge "n" number of messages from replied message
 /del - Delete Replied Message
 /promote - Promote A Member
 /fullpromote - Promote A Member With All Rights
@@ -171,17 +172,20 @@ async def admin_cache_func(_, cmu: ChatMemberUpdated):
 @app.on_message(filters.command("purge") & ~filters.edited & ~filters.private)
 @adminsOnly("can_delete_messages")
 async def purgeFunc(_, message: Message):
+    repliedmsg = message.reply_to_message
     await message.delete()
-
-    if not message.reply_to_message:
+    if not repliedmsg:
         return await message.reply_text("Reply to a message to purge from.")
-
+    splitted = message.text.split(" ")
+    try:count = int(splitted[1]) if len(splitted) > 1 and int(splitted[1]) \
+        + repliedmsg.message_id <= message.message_id else None
+    except ValueError:count = None
     chat_id = message.chat.id
     message_ids = []
 
     for message_id in range(
-            message.reply_to_message.message_id,
-            message.message_id,
+            repliedmsg.message_id,
+            repliedmsg.message_id + count if count else message.message_id,
     ):
         message_ids.append(message_id)
 

--- a/wbb/modules/admin.py
+++ b/wbb/modules/admin.py
@@ -174,18 +174,29 @@ async def admin_cache_func(_, cmu: ChatMemberUpdated):
 async def purgeFunc(_, message: Message):
     repliedmsg = message.reply_to_message
     await message.delete()
+
     if not repliedmsg:
         return await message.reply_text("Reply to a message to purge from.")
-    splitted = message.text.split(" ")
-    try:count = int(splitted[1]) if len(splitted) > 1 and int(splitted[1]) \
-        + repliedmsg.message_id <= message.message_id else None
-    except ValueError:count = None
+
+    cmd = message.command
+    try:
+
+        if len(cmd) > 1:
+            purge_to = repliedmsg.message_id + int(cmd[1])
+            if purge_to > message.message_id:
+                purge_to = message.message_id
+        else:
+            purge_to = message.message_id
+
+    except ValueError:
+        purge_to = message.message_id
+
     chat_id = message.chat.id
     message_ids = []
 
     for message_id in range(
             repliedmsg.message_id,
-            repliedmsg.message_id + count if count else message.message_id,
+            purge_to,
     ):
         message_ids.append(message_id)
 

--- a/wbb/modules/admin.py
+++ b/wbb/modules/admin.py
@@ -179,17 +179,12 @@ async def purgeFunc(_, message: Message):
         return await message.reply_text("Reply to a message to purge from.")
 
     cmd = message.command
-    try:
-
-        if len(cmd) > 1:
-            purge_to = repliedmsg.message_id + int(cmd[1])
-            if purge_to > message.message_id:
-                purge_to = message.message_id
-        else:
+    if len(cmd) > 1 and cmd[1].isdigit():
+        purge_to = repliedmsg.message_id + int(cmd[1])
+        if purge_to > message.message_id:
             purge_to = message.message_id
-
-    except ValueError:
-        purge_to = message.message_id
+    else:
+        purge_to = message.message_id   
 
     chat_id = message.chat.id
     message_ids = []


### PR DESCRIPTION
Users will be able to purge `n` number of messages (from the replied message) by providing the message count in `/purge` command: `/purge [n]`.
Edit: this implementation has been tested in an instance of wbb deployed locally