### PR TITLE
fix: create `Back` button only in case of less then 4 columns

### DIFF
--- a/wbb/utils/misc.py
+++ b/wbb/utils/misc.py
@@ -103,6 +103,15 @@ def paginate_modules(page_n, module_dict, prefix, chat=None):
                 ),
             )
         ]
+    else:
+        pairs = pairs[modulo_page * COLUMN_SIZE : COLUMN_SIZE * (modulo_page + 1)] + [
+            (   
+                EqInlineKeyboardButton(
+                    "Back",
+                    callback_data="{}_home({})".format(prefix, modulo_page),
+                ),
+            )
+        ]
 
     return pairs
 


### PR DESCRIPTION
This pull request fixes an issue where the Back and Navigation buttons were only created, when there were more than 4 columns or 12 buttons. The Back button is now created when there are less than 4 columns or 12 buttons. This ensures that the Back button is displayed in case of fewer buttons.

Additional Information:
The fix is a simple change that has been tested.

I hope this helps!