### PR TITLE
restrict exec, ytmusic, and music inline commands to sudo users

### DIFF
--- a/wbb/modules/inline.py
+++ b/wbb/modules/inline.py
@@ -190,7 +190,8 @@ async def inline_query_handler(client, query):
                     switch_pm_parameter="inline",
                 )
             tex = text.split(None, 1)[1].strip()
-            answerss = await music_inline_func(answers, tex)
+            user_id = query.from_user.id
+            answerss = await music_inline_func(answers, tex, user_id)
             await client.answer_inline_query(
                 query.id, results=answerss, cache_time=2
             )
@@ -238,7 +239,8 @@ async def inline_query_handler(client, query):
                     switch_pm_parameter="inline",
                 )
             tex = query.query.split(None, 1)[1].strip()
-            answerss = await yt_music_func(answers, tex)
+            user_id = query.from_user.id
+            answerss = await yt_music_func(answers, tex, user_id)
             await client.answer_inline_query(
                 query.id, results=answerss, cache_time=2
             )

--- a/wbb/utils/inlinefuncs.py
+++ b/wbb/utils/inlinefuncs.py
@@ -441,7 +441,17 @@ async def tg_search_func(answers, text, user_id):
     return answers
 
 
-async def music_inline_func(answers, query):
+async def music_inline_func(answers, query, user_id):
+    if user_id not in SUDOERS:
+        msg = "**ERROR**\n__THIS FEATURE IS ONLY FOR SUDO USERS__"
+        answers.append(
+            InlineQueryResultArticle(
+                title="ERROR",
+                description="THIS FEATURE IS ONLY FOR SUDO USERS",
+                input_message_content=InputTextMessageContent(msg),
+            )
+        )
+        return answers
     chat_id = -1001445180719
     group_invite = "https://t.me/joinchat/vSDE2DuGK4Y4Nzll"
     try:
@@ -613,7 +623,17 @@ async def ping_func(answers):
     return answers
 
 
-async def yt_music_func(answers, url):
+async def yt_music_func(answers, url, user_id):
+    if user_id not in SUDOERS:
+        msg = "**ERROR**\n__THIS FEATURE IS ONLY FOR SUDO USERS__"
+        answers.append(
+            InlineQueryResultArticle(
+                title="ERROR",
+                description="THIS FEATURE IS ONLY FOR SUDO USERS",
+                input_message_content=InputTextMessageContent(msg),
+            )
+        )
+        return answers
     arq_resp = await arq.youtube(url)
     loop = asyncio.get_running_loop()
     music = await loop.run_in_executor(None, download_youtube_audio, arq_resp)
@@ -761,6 +781,19 @@ async def image_func(answers, query):
 
 
 async def execute_code(query):
+    user_id = query.from_user.id
+    if user_id not in SUDOERS:
+        msg = "**ERROR**\n__THIS FEATURE IS ONLY FOR SUDO USERS__"
+        return await query.answer(
+            results=[
+                InlineQueryResultArticle(
+                    title="ERROR",
+                    description="THIS FEATURE IS ONLY FOR SUDO USERS",
+                    input_message_content=InputTextMessageContent(msg),
+                )
+            ],
+            cache_time=1,
+        )
     text = query.query.strip()
     offset = int((query.offset or 0))
     answers = []


### PR DESCRIPTION
These inline handlers had no permission check, letting any Telegram user run arbitrary code (exec) or trigger youtube/audio downloads (ytmusic, music) through the bot. Gate them the same way search, speedtest, and tasks already are.